### PR TITLE
Hide filters once expenses are loaded

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -28,33 +28,36 @@ async function loadExpenses() {
 
     if (data.length === 0) {
       tableContainer.innerHTML = 'No hay datos para mostrar.';
-      return;
+    } else {
+      const html = data.map(row => `
+        <tr>
+          <td>${row[0]}</td>
+          <td>${row[1]}</td>
+          <td>${row[2]}</td>
+          <td>${row[3]}</td>
+        </tr>
+      `).join('');
+
+      tableContainer.innerHTML = `
+        <table>
+          <thead>
+            <tr>
+              <th>Fecha</th>
+              <th>Categoría</th>
+              <th>Subcategoría</th>
+              <th>Monto</th>
+            </tr>
+          </thead>
+          <tbody>${html}</tbody>
+        </table>
+      `;
     }
-
-    const html = data.map(row => `
-      <tr>
-        <td>${row[0]}</td>
-        <td>${row[1]}</td>
-        <td>${row[2]}</td>
-        <td>${row[3]}</td>
-      </tr>
-    `).join('');
-
-    tableContainer.innerHTML = `
-      <table>
-        <thead>
-          <tr>
-            <th>Fecha</th>
-            <th>Categoría</th>
-            <th>Subcategoría</th>
-            <th>Monto</th>
-          </tr>
-        </thead>
-        <tbody>${html}</tbody>
-      </table>
-    `;
   } catch (error) {
     tableContainer.innerHTML = '❌ Error al obtener datos.';
     console.error(error);
   }
+
+  // Ocultar filtros y título cuando aparezca la tabla o el mensaje
+  document.getElementById('view-title').style.display = 'none';
+  document.getElementById('filters').style.display = 'none';
 }

--- a/view.html
+++ b/view.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   <div class="container">
-    <h2>Consultar Gastos</h2>
-    <div class="filters">
+    <h2 id="view-title">Consultar Gastos</h2>
+    <div class="filters" id="filters">
       <label for="month">📅 Mes</label>
       <input type="month" id="month" />
 
@@ -27,12 +27,15 @@
       </select>
 
       <div class="form-buttons">
-        <button type="button" onclick="loadExpenses()" class="btn-main">🔍 Filtrar</button>
-        <a href="index.html" class="btn-secondary">Volver</a>
+        <button type="button" onclick="loadExpenses()" class="btn-main" id="filter-btn">🔍 Filtrar</button>
       </div>
     </div>
 
     <div id="expenses-table-container"></div>
+
+    <div class="form-buttons">
+      <a href="index.html" class="btn-secondary" id="back-button">Volver</a>
+    </div>
   </div>
   <script src="js/view.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- hide filters section and page title once expenses table is displayed
- add separate back button after the table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865682b2ccc832c9ba39de44d07ad31