### PR TITLE
Update table container width dynamically

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -69,6 +69,14 @@ async function loadExpenses() {
           <tbody>${html}</tbody>
         </table>
       `;
+
+      // Ajustar el ancho del contenedor de acuerdo a la cantidad de registros
+      const container = document.querySelector('.container');
+      const baseWidth = 400; // ancho inicial en px
+      const maxWidth = 800;  // límite de crecimiento en px
+      const calculated = Math.min(baseWidth + data.length * 20, maxWidth);
+      container.style.maxWidth = `${calculated}px`;
+      container.style.width = '95%';
     }
   } catch (error) {
     tableContainer.innerHTML = '❌ Error al obtener datos.';


### PR DESCRIPTION
## Summary
- adjust the width of the table container based on the number of records returned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68656bdc4844832c80fca4da301cdfb2